### PR TITLE
Windows improvements for unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Easy to setup, convenient, universal, parallel, http/https proxy daemon. Setup in 1 minute, run, configure, adapt. Proxying based on excellent node-http-proxy.",
   "main": "src/HttpMaster.js",
   "scripts": {
-    "test": "./node_modules/istanbul/lib/cli.js cover node_modules/mocha/bin/_mocha -- -R spec tests/"
+    "test": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec tests/"
   },
   "repository": {
     "type": "git",

--- a/tests/certScannerTest.js
+++ b/tests/certScannerTest.js
@@ -178,22 +178,22 @@ describe('SSL directory scanner', function() {
     scanner.scan(function(err, scannedConfig) {
       assert.deepEqualIgnoreOrder(scannedConfig, {
         'pacmanvps.com': {
-          'cert': sslDir + 'pacmanvps.com/startssl-wildcard.pacmanvps.com.pem'
+          'cert': path.normalize(sslDir + 'pacmanvps.com/startssl-wildcard.pacmanvps.com.pem')
         },
         '*.pacmanvps.com': {
-          'cert': sslDir + 'pacmanvps.com/startssl-wildcard.pacmanvps.com.pem'
+          'cert': path.normalize(sslDir + 'pacmanvps.com/startssl-wildcard.pacmanvps.com.pem')
         },
         'jira-e-instruments.com': {
-          'cert': sslDir + 'jira-e-instruments.com/unizeto-jira-e-instruments.com.pem'
+          'cert': path.normalize(sslDir + 'jira-e-instruments.com/unizeto-jira-e-instruments.com.pem')
         },
         'www.jira-e-instruments.com': {
-          'cert': sslDir + 'jira-e-instruments.com/unizeto-jira-e-instruments.com.pem'
+          'cert': path.normalize(sslDir + 'jira-e-instruments.com/unizeto-jira-e-instruments.com.pem')
         },
         'softwaremill.com': {
-          'cert': sslDir + 'softwaremill.com/unizeto-wildcard.softwaremill.com.pem'
+          'cert': path.normalize(sslDir + 'softwaremill.com/unizeto-wildcard.softwaremill.com.pem')
         },
         '*.softwaremill.com': {
-          'cert': sslDir + 'softwaremill.com/unizeto-wildcard.softwaremill.com.pem'
+          'cert': path.normalize(sslDir + 'softwaremill.com/unizeto-wildcard.softwaremill.com.pem')
         }
       });
       cb(err);
@@ -207,28 +207,28 @@ describe('SSL directory scanner', function() {
     scanner.scan(function(err, scannedConfig) {
       assert.deepEqualIgnoreOrder(scannedConfig, {
         'pacmanvps.com': {
-          'cert': sslDir + 'pacmanvps.com/startssl-wildcard.pacmanvps.com.pem',
-          'ca': sslDir + 'ca/startssl/startssl.pem'
+          'cert': path.normalize(sslDir + 'pacmanvps.com/startssl-wildcard.pacmanvps.com.pem'),
+          'ca': path.normalize(sslDir + 'ca/startssl/startssl.pem')
         },
         '*.pacmanvps.com': {
-          'cert': sslDir + 'pacmanvps.com/startssl-wildcard.pacmanvps.com.pem',
-          'ca': sslDir + 'ca/startssl/startssl.pem'
+          'cert': path.normalize(sslDir + 'pacmanvps.com/startssl-wildcard.pacmanvps.com.pem'),
+          'ca': path.normalize(sslDir + 'ca/startssl/startssl.pem')
         },
         'jira-e-instruments.com': {
-          'cert': sslDir + 'jira-e-instruments.com/unizeto-jira-e-instruments.com.pem',
-          'ca': sslDir + 'ca/unizeto/unizeto.pem'
+          'cert': path.normalize(sslDir + 'jira-e-instruments.com/unizeto-jira-e-instruments.com.pem'),
+          'ca': path.normalize(sslDir + 'ca/unizeto/unizeto.pem')
         },
         'www.jira-e-instruments.com': {
-          'cert': sslDir + 'jira-e-instruments.com/unizeto-jira-e-instruments.com.pem',
-          'ca': sslDir + 'ca/unizeto/unizeto.pem'
+          'cert': path.normalize(sslDir + 'jira-e-instruments.com/unizeto-jira-e-instruments.com.pem'),
+          'ca': path.normalize(sslDir + 'ca/unizeto/unizeto.pem')
         },
         'softwaremill.com': {
-          'cert': sslDir + 'softwaremill.com/unizeto-wildcard.softwaremill.com.pem',
-          'ca': sslDir + 'ca/unizeto/unizeto.pem'
+          'cert': path.normalize(sslDir + 'softwaremill.com/unizeto-wildcard.softwaremill.com.pem'),
+          'ca': path.normalize(sslDir + 'ca/unizeto/unizeto.pem')
         },
         '*.softwaremill.com': {
-          'cert': sslDir + 'softwaremill.com/unizeto-wildcard.softwaremill.com.pem',
-          'ca': sslDir + 'ca/unizeto/unizeto.pem'
+          'cert': path.normalize(sslDir + 'softwaremill.com/unizeto-wildcard.softwaremill.com.pem'),
+          'ca': path.normalize(sslDir + 'ca/unizeto/unizeto.pem')
         }
       });
       cb(err);


### PR DESCRIPTION
allow 'npm test' to work on windows
normalize path separators for certificate scanner tests on windows

tested on windows 8.1 and debian 7